### PR TITLE
To wrap the closer as a nop for request body

### DIFF
--- a/cos.go
+++ b/cos.go
@@ -177,6 +177,7 @@ func (c *Client) newRequest(ctx context.Context, opt *sendOptions) (req *http.Re
 	}
 	if v := req.Header.Get("Content-Length"); req.ContentLength == 0 && v != "" && v != "0" {
 		req.ContentLength, _ = strconv.ParseInt(v, 10, 64)
+		req.Body = ioutil.NopCloser(reader)
 	}
 
 	if contentMD5 != "" {


### PR DESCRIPTION
Signed-off-by: jojohappy <sarahdj0917@gmail.com>

变更:
由于 Golang 的 `net/http` 包在做 `client.Do(req)` 时默认会调用 `req.Body.Close()`, 如果我们上传的 `Object` 是文件时，文件句柄将会被关闭，这样就没有办法在外部程序复用这个文件句柄，同时会有 `file already closed` 的错误发生。

这里的修改尝试在 `io.Reader` 外面再封装一个 `NopCloser` ，默认 `Close()` 返回 `nil`。对于文件句柄的关闭操作应当由调用方来处理。
