### PR TITLE
Close response bodies

### DIFF
--- a/_example/object/append.go
+++ b/_example/object/append.go
@@ -57,13 +57,16 @@ func main() {
 		panic(err)
 		return
 	}
+	defer resp.Body.Close()
 	fmt.Printf("%s\n", resp.Status)
 
 	// head
-	if _, err = c.Object.Head(ctx, name, nil); err != nil {
+	resp, err = c.Object.Head(ctx, name, nil)
+	if err != nil {
 		panic(err)
 		return
 	}
+	defer resp.Body.Close()
 
 	// 再次 append
 	data = genBigData(1024 * 1024 * 5)
@@ -72,5 +75,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 	fmt.Printf("%s\n", resp.Status)
 }

--- a/_example/object/completeMultipartUpload.go
+++ b/_example/object/completeMultipartUpload.go
@@ -35,6 +35,8 @@ func uploadPart(c *cos.Client, name string, uploadID string, blockSize, n int) s
 	resp, err := c.Object.UploadPart(
 		context.Background(), name, uploadID, n, f, nil,
 	)
+	defer resp.Body.Close()
+
 	if err != nil {
 		panic(err)
 	}

--- a/_example/object/copy.go
+++ b/_example/object/copy.go
@@ -36,10 +36,11 @@ func main() {
 	expected := "test"
 	f := strings.NewReader(expected)
 
-	_, err := c.Object.Put(context.Background(), source, f, nil)
+	resp, err := c.Object.Put(context.Background(), source, f, nil)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	soruceURL := fmt.Sprintf("%s/%s", u.Host, source)
 	dest := fmt.Sprintf("test/objectMove_%d.go", time.Now().Nanosecond())
@@ -50,7 +51,7 @@ func main() {
 	}
 	fmt.Printf("%+v\n\n", res)
 
-	resp, err := c.Object.Get(context.Background(), dest, nil)
+	resp, err = c.Object.Get(context.Background(), dest, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/_example/object/delete.go
+++ b/_example/object/delete.go
@@ -29,8 +29,9 @@ func main() {
 
 	name := "test/objectPut.go"
 
-	_, err := c.Object.Delete(context.Background(), name)
+	resp, err := c.Object.Delete(context.Background(), name)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 }

--- a/_example/object/head.go
+++ b/_example/object/head.go
@@ -29,8 +29,9 @@ func main() {
 	})
 
 	name := "test/hello.txt"
-	_, err := c.Object.Head(context.Background(), name, nil)
+	resp, err := c.Object.Head(context.Background(), name, nil)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 }

--- a/_example/object/listParts.go
+++ b/_example/object/listParts.go
@@ -38,6 +38,7 @@ func uploadPart(c *cos.Client, name string, uploadID string, blockSize, n int) s
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 	fmt.Printf("%s\n", resp.Status)
 	return resp.Header.Get("Etag")
 }

--- a/_example/object/options.go
+++ b/_example/object/options.go
@@ -29,11 +29,12 @@ func main() {
 
 	name := "test/hello.txt"
 	opt := &cos.ObjectOptionsOptions{
-		Origin: "http://www.qq.com",
+		Origin:                     "http://www.qq.com",
 		AccessControlRequestMethod: "PUT",
 	}
-	_, err := c.Object.Options(context.Background(), name, opt)
+	resp, err := c.Object.Options(context.Background(), name, opt)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 }

--- a/_example/object/put.go
+++ b/_example/object/put.go
@@ -29,10 +29,11 @@ func main() {
 	name := "test/objectPut.go"
 	f := strings.NewReader("test")
 
-	_, err := c.Object.Put(context.Background(), name, f, nil)
+	resp, err := c.Object.Put(context.Background(), name, f, nil)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	// 测试上传以及特殊字符
 	name = "test/put_ + !'()* option.go"

--- a/_example/object/putACL.go
+++ b/_example/object/putACL.go
@@ -33,10 +33,11 @@ func main() {
 		},
 	}
 	name := "test/hello.txt"
-	_, err := c.Object.PutACL(context.Background(), name, opt)
+	resp, err := c.Object.PutACL(context.Background(), name, opt)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	// with body
 	opt = &cos.ObjectPutACLOptions{
@@ -57,8 +58,9 @@ func main() {
 		},
 	}
 
-	_, err = c.Object.PutACL(context.Background(), name, opt)
+	resp, err = c.Object.PutACL(context.Background(), name, opt)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 }

--- a/_example/object/putWithPresignedURL.go
+++ b/_example/object/putWithPresignedURL.go
@@ -39,10 +39,11 @@ func main() {
 	f := strings.NewReader("test")
 
 	// 通过生成签名 header 上传文件
-	_, err := c.Object.Put(ctx, name, f, nil)
+	resp, err := c.Object.Put(ctx, name, f, nil)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 
 	// 获取预签名授权 URL
 	opt := &cos.ObjectPutOptions{

--- a/_example/object/uploadFile.go
+++ b/_example/object/uploadFile.go
@@ -36,8 +36,9 @@ func main() {
 	}
 	fmt.Println(s.Size())
 
-	_, err = c.Object.Put(context.Background(), name, f, nil)
+	resp, err = c.Object.Put(context.Background(), name, f, nil)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 }

--- a/_example/object/uploadPart.go
+++ b/_example/object/uploadPart.go
@@ -44,10 +44,11 @@ func main() {
 	uploadID := up.UploadID
 
 	f := strings.NewReader("test heoo")
-	_, err := c.Object.UploadPart(
+	resp, err := c.Object.UploadPart(
 		context.Background(), name, uploadID, 1, f, nil,
 	)
 	if err != nil {
 		panic(err)
 	}
+	defer resp.Body.Close()
 }

--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,3 +1,4 @@
 tenets:
 - import: codelingo/effective-go
 - import: codelingo/code-review-comments
+- import: codelingo/mozillazg-go-cos

--- a/object_test.go
+++ b/object_test.go
@@ -39,6 +39,7 @@ func TestObjectService_Get(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Object.Get returned error: %v", err)
 	}
+	defer resp.Body.Close()
 
 	b, _ := ioutil.ReadAll(resp.Body)
 	ref := string(b)
@@ -76,6 +77,7 @@ func TestObjectService_Get_with_PresignedURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Object.Get returned error: %v", err)
 	}
+	defer resp.Body.Close()
 
 	b, _ := ioutil.ReadAll(resp.Body)
 	ref := string(b)
@@ -114,10 +116,11 @@ func TestObjectService_Put(t *testing.T) {
 	})
 
 	r := bytes.NewReader([]byte("hello"))
-	_, err := client.Object.Put(context.Background(), name, r, opt)
+	resp, err := client.Object.Put(context.Background(), name, r, opt)
 	if err != nil {
 		t.Fatalf("Object.Put returned error: %v", err)
 	}
+	defer resp.Body.Close()
 
 }
 
@@ -153,10 +156,11 @@ func TestObjectService_Put_with_PresignedURL(t *testing.T) {
 	})
 
 	r := bytes.NewReader([]byte("hello"))
-	_, err := client.Object.Put(context.Background(), name, r, opt)
+	resp, err := client.Object.Put(context.Background(), name, r, opt)
 	if err != nil {
 		t.Fatalf("Object.Put returned error: %v", err)
 	}
+	defer resp.Body.Close()
 
 }
 
@@ -192,10 +196,12 @@ func TestObjectService_Put_not_close(t *testing.T) {
 	})
 
 	r := newTraceCloser(bytes.NewReader([]byte("hello")))
-	_, err := client.Object.Put(context.Background(), name, r, opt)
+	resp, err := client.Object.Put(context.Background(), name, r, opt)
 	if err != nil {
 		t.Fatalf("Object.Put returned error: %v", err)
 	}
+	defer resp.Body.Close()
+
 	if r.Called {
 		t.Fatal("Should not close input")
 	}
@@ -212,10 +218,11 @@ func TestObjectService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	_, err := client.Object.Delete(context.Background(), name)
+	resp, err := client.Object.Delete(context.Background(), name)
 	if err != nil {
 		t.Fatalf("Object.Delete returned error: %v", err)
 	}
+	defer resp.Body.Close()
 }
 
 func TestObjectService_Head(t *testing.T) {
@@ -232,10 +239,11 @@ func TestObjectService_Head(t *testing.T) {
 		IfModifiedSince: "Mon, 12 Jun 2017 05:36:19 GMT",
 	}
 
-	_, err := client.Object.Head(context.Background(), name, opt)
+	resp, err := client.Object.Head(context.Background(), name, opt)
 	if err != nil {
 		t.Fatalf("Object.Head returned error: %v", err)
 	}
+	defer resp.Body.Close()
 
 }
 
@@ -251,14 +259,15 @@ func TestObjectService_Options(t *testing.T) {
 	})
 
 	opt := &ObjectOptionsOptions{
-		Origin: "www.qq.com",
+		Origin:                     "www.qq.com",
 		AccessControlRequestMethod: "PUT",
 	}
 
-	_, err := client.Object.Options(context.Background(), name, opt)
+	resp, err := client.Object.Options(context.Background(), name, opt)
 	if err != nil {
 		t.Fatalf("Object.Options returned error: %v", err)
 	}
+	defer resp.Body.Close()
 
 }
 
@@ -297,10 +306,11 @@ func TestObjectService_Append(t *testing.T) {
 	})
 
 	r := bytes.NewReader([]byte("hello"))
-	_, err := client.Object.Append(context.Background(), name, position, r, opt)
+	resp, err := client.Object.Append(context.Background(), name, position, r, opt)
 	if err != nil {
 		t.Fatalf("Object.Append returned error: %v", err)
 	}
+	defer resp.Body.Close()
 }
 
 func TestObjectService_Append_not_close(t *testing.T) {
@@ -342,10 +352,12 @@ func TestObjectService_Append_not_close(t *testing.T) {
 	})
 
 	r := newTraceCloser(bytes.NewReader([]byte("hello")))
-	_, err := client.Object.Append(context.Background(), name, position, r, opt)
+	resp, err := client.Object.Append(context.Background(), name, position, r, opt)
 	if err != nil {
 		t.Fatalf("Object.Append returned error: %v", err)
 	}
+	defer resp.Body.Close()
+
 	if r.Called {
 		t.Fatal("Should not close input")
 	}


### PR DESCRIPTION
Fix responses returned from `Object` methods whose bodies have not been closed. This leads to connections not being recycled. 

Add CodeLingo tenet to catch this issue during code reviews.

I've fixed instances in example and test files, the [`Bucket` struct](https://github.com/mozillazg/go-cos/blob/master/bucket.go) may have similar issues which we can catch by editing the tenet. Are there other structs which may contain unclosed connections?